### PR TITLE
Runs Support

### DIFF
--- a/phantomas/client.py
+++ b/phantomas/client.py
@@ -8,7 +8,7 @@ from subprocess import Popen, PIPE
 
 from .errors import PhantomasRunError,\
     PhantomasResponseParsingError, PhantomasFailedError
-from .results import Results
+from .results import Results, Runs
 from .utils import format_args
 
 
@@ -84,7 +84,10 @@ class Phantomas(object):
         except Exception:
             raise PhantomasResponseParsingError("Unable to parse the response")
 
-        return Results(self._url, results)
+        if self._options.get("runs", 0) > 1:
+            return Runs(self._url, results)
+        else:
+            return Results(self._url, results)
 
     def __repr__(self):
         return '<Phantomas for {url}>'.format(url=self._url)

--- a/phantomas/results.py
+++ b/phantomas/results.py
@@ -41,3 +41,29 @@ class Results(object):
             url=self._url,
             count=len(self._metrics)
         )
+
+
+class Runs(object):
+    """ Phantomas runs wrapper """
+
+    def __init__(self, url, data):
+        for key in ["runs", "stats"]:
+            assert data.get(key) is not None
+
+        self._url = url
+        self._runs = [Results(url=self.url, data=run_data) for run_data in data["runs"]]
+        self._stats = data.get("stats")
+
+    @property
+    def url(self):
+        return self._url
+
+    @property
+    def stats(self):
+        return self._stats
+
+    @property
+    def runs(self):
+        return self._runs or []
+
+


### PR DESCRIPTION
Currently, if the argument "runs"  is included an assertion error is raised. These changes account for requests that use 'runs' by returning a ```Runs``` object instead:
```
>>>r = Phantomas(url="http://www.example.com", runs=2).run()
>>>dir(r)
['__class__',...,'runs', 'stats', 'url']
>>> dir(r.runs[0])
['__class__',...,'get_generator', 'get_metric', 'get_metrics', 'get_offenders', 'get_url']
```
I should probably have submitted a bug report first, but I have little time and this tool is too good to pass up :)